### PR TITLE
cpu counting for faster builds (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The user manual is available at [www.domoticz.com][appurl]
 
 ## Versions
 
++ **26.11.2017:** Use cpu core counting routine to speed up build time.
 + **28.05.2017:** Rebase to alpine 3.6.
 + **26.02.2017:** Add curl and replace openssl with libressl.
 + **11.02.2017:** Update README.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ added cpu core counting routine to speed up builds, dependant on node used for how much faster build will be 

+ on quad core node with hyperthreading and the routine allocating 5 threads on the second build, times as follows

+ 22m56.571s with current Dockerfile

+ 8m41.040s with cpu routine