### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.9
+FROM lsiobase/alpine:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN \
 	boost-thread \
 	curl \
 	eudev-libs \
+	iputils \
 	libressl \
 	openssh \
 	python3-dev && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm64v8-3.9
+FROM lsiobase/alpine:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -54,6 +54,7 @@ RUN \
 	boost-thread \
 	curl \
 	eudev-libs \
+	iputils \
 	libressl \
 	openssh \
 	python3-dev && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm32v7-3.9
+FROM lsiobase/alpine:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -54,6 +54,7 @@ RUN \
 	boost-thread \
 	curl \
 	eudev-libs \
+	iputils \
 	libressl \
 	openssh \
 	python3-dev && \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This image provides various versions that are available via tags. `latest` tag u
 
 | Tag | Description |
 | :----: | --- |
-| latest | Current latest head from master at https://github.com/domoticz/domoticz. |
+| latest | Current latest head from development at https://github.com/domoticz/domoticz. |
 | stable | Latest stable version. |
 | stable-4.9700 | Old stable version. Will not be updated anymore! |
 | stable-3.815 | Old stable version. Will not be updated anymore! |
@@ -190,6 +190,9 @@ Below are the instructions for updating containers:
   containrrr/watchtower \
   --run-once domoticz
   ```
+
+**Note:** We do not endorse the use of Watchtower as a solution to automated updates of existing Docker containers. In fact we generally discourage automated updates. However, this is a useful tool for one-time manual updates of containers where you have forgotten the original parameters. In the long term, we highly recommend using Docker Compose.
+
 * You can also remove the old dangling images: `docker image prune`
 
 ## Building locally
@@ -213,6 +216,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.06.19:** - Rebasing to alpine 3.10. Add iputils for ping. Fix typo in readme. Fix permissions for custom icons.
 * **12.05.19:** - Add boost dependencies and turn off static boost build. Bump to Alpine 3.9.
 * **30.03.19:** - Add env variable to set webroot.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -18,7 +18,7 @@ available_architectures:
 # development version
 development_versions: true
 development_versions_items:
-  - { tag: "latest", desc: "Current latest head from master at https://github.com/domoticz/domoticz." }
+  - { tag: "latest", desc: "Current latest head from development at https://github.com/domoticz/domoticz." }
   - { tag: "stable", desc: "Latest stable version." }
   - { tag: "stable-4.9700", desc: "Old stable version. Will not be updated anymore!" }
   - { tag: "stable-3.815", desc: "Old stable version. Will not be updated anymore!" }
@@ -75,7 +75,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10. Add iputils for ping. Fix typo in readme. Fix permissions for custom icons." }
   - { date: "12.05.19:", desc: "Add boost dependencies and turn off static boost build. Bump to Alpine 3.9." }
   - { date: "30.03.19:", desc: "Add env variable to set webroot." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -75,6 +75,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "12.05.19:", desc: "Add boost dependencies and turn off static boost build. Bump to Alpine 3.9." }
   - { date: "30.03.19:", desc: "Add env variable to set webroot." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -22,6 +22,7 @@ fi
 # set permissions for /config
 chown -R abc:abc \
 	/config \
-	/tmp
+	/tmp \
+	/var/lib/domoticz
 chmod -R 764 \
 	/config


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.