### PR TITLE
Rebase to Alpine 3.11. Change to using apk install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.10
+FROM lsiobase/alpine:3.11
 
 # set version label
 ARG BUILD_DATE
@@ -16,45 +16,34 @@ COPY patches/ /
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-	argp-standalone \
 	autoconf \
 	automake \
 	binutils \
-	boost-dev \
 	cmake \
 	confuse-dev \
-	curl-dev \
 	doxygen \
 	eudev-dev \
 	g++ \
 	gcc \
 	git \
 	gzip \
-	libcurl \
 	libftdi1-dev \
 	libressl-dev \
-	libusb-compat-dev \
-	libusb-dev \
-	linux-headers \
 	make \
-	mosquitto-dev \
 	musl-dev \
-	openzwave-dev \
 	pkgconf \
-	sqlite-dev \
-	tar \
-	zlib-dev && \
+	tar && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
- 	boost \
-	boost-thread \
-	boost-system \
 	curl \
+	domoticz \
 	eudev-libs \
 	iputils \
-	libressl \
+	mosquitto-clients \
 	openssh \
+	openssl \
 	openzwave \
+	python3 \
 	python3-dev && \
  echo "**** link libftdi libs ****" && \
  ln -s /usr/lib/libftdi1.so /usr/lib/libftdi.so && \
@@ -78,41 +67,12 @@ RUN \
  mv /tmp/telldus-core/client/telldus-core.h /usr/include/telldus-core.h && \
  ln -s /usr/lib/libtelldus-core.so.2.1.2 /usr/lib/libtelldus-core.so.2 && \
  ln -s /usr/lib/libtelldus-core.so.2 /usr/lib/libtelldus-core.so && \
- echo "**** build domoticz ****" && \
- if [ -z ${DOMOTICZ_RELEASE+x} ]; then \
- 	DOMOTICZ_RELEASE=$(curl -sX GET "https://api.github.com/repos/domoticz/domoticz/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone -b "${DOMOTICZ_RELEASE}" https://github.com/domoticz/domoticz.git /tmp/domoticz && \
- cd /tmp/domoticz && \
- cmake \
-	-DBUILD_SHARED_LIBS=True \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX=/var/lib/domoticz \
-	-DOpenZWave=/usr/lib/libopenzwave.so \
-	-DUSE_BUILTIN_LUA=ON \
-	-DUSE_BUILTIN_MQTT=ON \
-	-DUSE_BUILTIN_SQLITE=OFF \
-	-DUSE_STATIC_BOOST=OFF \
-	-DUSE_STATIC_LIBSTDCXX=OFF \
-	-DUSE_STATIC_OPENZWAVE=OFF \
-	-Wno-dev && \
- make && \
- make install && \
  echo "**** install BroadlinkRM2 plugin dependencies ****" && \
  git clone https://github.com/mjg59/python-broadlink.git /tmp/python-broadlink && \
  cd /tmp/python-broadlink && \
  git checkout 8bc67af6 && \
  pip3 install . && \
  pip3 install pyaes && \
- echo "**** determine runtime packages using scanelf ****" && \
- RUNTIME_PACKAGES="$( \
-	scanelf --needed --nobanner /var/lib/domoticz/domoticz \
-	| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-	| sort -u \
-	| xargs -r apk info --installed \
-	| sort -u \
-	)" && \
  apk add --no-cache \
 	$RUNTIME_PACKAGES && \
  echo "**** add abc to dialout and cron group ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm64v8-3.10
+FROM lsiobase/alpine:arm64v8-3.11
 
 # set version label
 ARG BUILD_DATE
@@ -16,45 +16,34 @@ COPY patches/ /
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-	argp-standalone \
 	autoconf \
 	automake \
 	binutils \
-	boost-dev \
 	cmake \
 	confuse-dev \
-	curl-dev \
 	doxygen \
 	eudev-dev \
 	g++ \
 	gcc \
 	git \
 	gzip \
-	libcurl \
 	libftdi1-dev \
 	libressl-dev \
-	libusb-compat-dev \
-	libusb-dev \
-	linux-headers \
 	make \
-	mosquitto-dev \
 	musl-dev \
-	openzwave-dev \
 	pkgconf \
-	sqlite-dev \
-	tar \
-	zlib-dev && \
+	tar && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
-  	boost \
-	boost-thread \
-	boost-system \
 	curl \
+	domoticz \
 	eudev-libs \
 	iputils \
-	libressl \
+	mosquitto-clients \
 	openssh \
+	openssl \
 	openzwave \
+	python3 \
 	python3-dev && \
  echo "**** link libftdi libs ****" && \
  ln -s /usr/lib/libftdi1.so /usr/lib/libftdi.so && \
@@ -78,43 +67,12 @@ RUN \
  mv /tmp/telldus-core/client/telldus-core.h /usr/include/telldus-core.h && \
  ln -s /usr/lib/libtelldus-core.so.2.1.2 /usr/lib/libtelldus-core.so.2 && \
  ln -s /usr/lib/libtelldus-core.so.2 /usr/lib/libtelldus-core.so && \
- echo "**** build domoticz ****" && \
- if [ -z ${DOMOTICZ_RELEASE+x} ]; then \
- 	DOMOTICZ_RELEASE=$(curl -sX GET "https://api.github.com/repos/domoticz/domoticz/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone -b "${DOMOTICZ_RELEASE}" https://github.com/domoticz/domoticz.git /tmp/domoticz && \
- cd /tmp/domoticz && \
- cmake \
-	-DBUILD_SHARED_LIBS=True \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX=/var/lib/domoticz \
-	-DOpenZWave=/usr/lib/libopenzwave.so \
-	-DUSE_BUILTIN_LUA=ON \
-	-DUSE_BUILTIN_MQTT=ON \
-	-DUSE_BUILTIN_SQLITE=OFF \
-	-DUSE_STATIC_BOOST=OFF \
-	-DUSE_STATIC_LIBSTDCXX=OFF \
-	-DUSE_STATIC_OPENZWAVE=OFF \
-	-Wno-dev && \
- make && \
- make install && \
  echo "**** install BroadlinkRM2 plugin dependencies ****" && \
  git clone https://github.com/mjg59/python-broadlink.git /tmp/python-broadlink && \
  cd /tmp/python-broadlink && \
  git checkout 8bc67af6 && \
  pip3 install . && \
  pip3 install pyaes && \
- echo "**** determine runtime packages using scanelf ****" && \
- RUNTIME_PACKAGES="$( \
-	scanelf --needed --nobanner /var/lib/domoticz/domoticz \
-	| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-	| sort -u \
-	| xargs -r apk info --installed \
-	| sort -u \
-	)" && \
- apk add --no-cache \
-	$RUNTIME_PACKAGES && \
  echo "**** add abc to dialout and cron group ****" && \
  usermod -a -G 16,20 abc && \
  echo " **** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm32v7-3.10
+FROM lsiobase/alpine:arm32v7-3.11
 
 # set version label
 ARG BUILD_DATE
@@ -16,45 +16,34 @@ COPY patches/ /
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-	argp-standalone \
 	autoconf \
 	automake \
 	binutils \
-	boost-dev \
 	cmake \
 	confuse-dev \
-	curl-dev \
 	doxygen \
 	eudev-dev \
 	g++ \
 	gcc \
 	git \
 	gzip \
-	libcurl \
 	libftdi1-dev \
 	libressl-dev \
-	libusb-compat-dev \
-	libusb-dev \
-	linux-headers \
 	make \
-	mosquitto-dev \
 	musl-dev \
-	openzwave-dev \
 	pkgconf \
-	sqlite-dev \
-	tar \
-	zlib-dev && \
+	tar && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
-  	boost \
-	boost-thread \
-	boost-system \
 	curl \
+	domoticz \
 	eudev-libs \
 	iputils \
-	libressl \
+	mosquitto-clients \
 	openssh \
+	openssl \
 	openzwave \
+	python3 \
 	python3-dev && \
  echo "**** link libftdi libs ****" && \
  ln -s /usr/lib/libftdi1.so /usr/lib/libftdi.so && \
@@ -73,48 +62,12 @@ RUN \
  cd /tmp/telldus-core && \
  cmake -DBUILD_TDADMIN=false -DCMAKE_INSTALL_PREFIX=/tmp/telldus-core . && \
  make && \
- echo "**** configure telldus core ****" && \
- mv /tmp/telldus-core/client/libtelldus-core.so.2.1.2 /usr/lib/libtelldus-core.so.2.1.2 && \
- mv /tmp/telldus-core/client/telldus-core.h /usr/include/telldus-core.h && \
- ln -s /usr/lib/libtelldus-core.so.2.1.2 /usr/lib/libtelldus-core.so.2 && \
- ln -s /usr/lib/libtelldus-core.so.2 /usr/lib/libtelldus-core.so && \
- echo "**** build domoticz ****" && \
- if [ -z ${DOMOTICZ_RELEASE+x} ]; then \
- 	DOMOTICZ_RELEASE=$(curl -sX GET "https://api.github.com/repos/domoticz/domoticz/releases/latest" \
-        | awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone -b "${DOMOTICZ_RELEASE}" https://github.com/domoticz/domoticz.git /tmp/domoticz && \
- cd /tmp/domoticz && \
- cmake \
-	-DBUILD_SHARED_LIBS=True \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX=/var/lib/domoticz \
-	-DOpenZWave=/usr/lib/libopenzwave.so \
-	-DUSE_BUILTIN_LUA=ON \
-	-DUSE_BUILTIN_MQTT=ON \
-	-DUSE_BUILTIN_SQLITE=OFF \
-	-DUSE_STATIC_BOOST=OFF \
-	-DUSE_STATIC_LIBSTDCXX=OFF \
-	-DUSE_STATIC_OPENZWAVE=OFF \
-	-Wno-dev && \
- make && \
- make install && \
  echo "**** install BroadlinkRM2 plugin dependencies ****" && \
  git clone https://github.com/mjg59/python-broadlink.git /tmp/python-broadlink && \
  cd /tmp/python-broadlink && \
  git checkout 8bc67af6 && \
  pip3 install . && \
  pip3 install pyaes && \
- echo "**** determine runtime packages using scanelf ****" && \
- RUNTIME_PACKAGES="$( \
-	scanelf --needed --nobanner /var/lib/domoticz/domoticz \
-	| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-	| sort -u \
-	| xargs -r apk info --installed \
-	| sort -u \
-	)" && \
- apk add --no-cache \
-	$RUNTIME_PACKAGES && \
  echo "**** add abc to dialout and cron group ****" && \
  usermod -a -G 16,20 abc && \
  echo " **** cleanup ****" && \

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,14 +2,12 @@
 
 # jenkins variables
 project_name: docker-domoticz
-external_type: github_stable
-release_type: prerelease
+external_type: na
+custom_version_command: "curl -s http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/ |awk -F '(domoticz-|.apk)' '/domoticz.*.apk/ {print $2}'"
+release_type: stable
 release_tag: stable
 ls_branch: stable
 repo_vars:
-  - EXT_GIT_BRANCH = 'master'
-  - EXT_USER = 'domoticz'
-  - EXT_REPO = 'domoticz'
   - BUILD_VERSION_ARG = 'DOMOTICZ_RELEASE'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-domoticz'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -75,6 +75,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.11.19:", desc: "Rebase to Alpine 3.11. Change to using apk install." }
   - { date: "24.11.19:", desc: "Change to using domoticz builtin Lua and MQTT." }
   - { date: "03.11.19:", desc: "2nd try setting capabilities for Domoticz binary." }
   - { date: "29.10.19:", desc: "Set capabilities for Domoticz binary so spawned processes can use sockets." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -8,6 +8,12 @@ mkdir -p \
 [[ ! -e /config/scripts ]] && \
 	cp -R /var/lib/domoticz/scripts /config/
 
+# delete update scripts
+[[ -e /config/scripts/update_domoticz ]] && \
+	rm -rf /config/scripts/update_domoticz
+	rm -rf /config/scripts/restart_domoticz
+	rm -rf /config/scripts/download_update.sh
+
 # generate ssl certificate
 if [ -z ${TEST_RUN+x} ]; then
 	if [ ! -e /config/keys/server_cert.pem ]; then
@@ -22,8 +28,7 @@ fi
 
 # set permissions for /config
 chown -R abc:abc \
-	/config
+	/config \
 	/tmp
-	/var/lib/domoticz
 chmod -R 764 \
 	/config

--- a/root/etc/services.d/domoticz/run
+++ b/root/etc/services.d/domoticz/run
@@ -3,12 +3,14 @@
 IFS=" " read -r -a RUN_ARRAY <<< "$WEBROOT"
 
 # set capabilities for domoticz binary
-setcap cap_net_raw=+eip /var/lib/domoticz/domoticz
+setcap cap_net_raw=+eip /usr/bin/domoticz
 
 exec \
-	s6-setuidgid abc /var/lib/domoticz/domoticz \
+	s6-setuidgid abc /usr/bin/domoticz \
+		-approot /usr/share/domoticz/ \
+		-dbase /config/domoticz.db \
+		-noupdate \
 		-sslwww 1443 \
 		-sslcert /config/keys/server_cert.pem \
 		-userdata /config/ \
-		-dbase /config/domoticz.db \
-		-webroot "${RUN_ARRAY[@]}"
+		-webroot "${RUN_ARRAY[@]}"		


### PR DESCRIPTION
Rebasing to alpine 3.11 and changing to using apk install instead of tormenting the build nodes for days with a build.

Must be tested locally on running system before merging.

Changed jenkins variables, so might need tweaking there from @thelamer 